### PR TITLE
Circle CIの有効化 -- その2

### DIFF
--- a/tools/circleci/push-to-master.sh
+++ b/tools/circleci/push-to-master.sh
@@ -21,7 +21,8 @@ fi
 REVISION=$(git rev-parse --short HEAD)
 
 # If there are anything to commit, do `git commit` and `git push`
-git add docs
+# -f flag is needed as docs is listed in .gitignore
+git add -f docs
 set +e
 ret=$(git status | grep -q 'nothing to commit'; echo $?)
 set -e


### PR DESCRIPTION
Circle CIジョブからignore対象のdocsディレクトリを`git add`するために`-f`フラグを追加します。