### PR TITLE
mdBook 0.4.5へアップグレード

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:edition-guide
+      - image: quay.io/rust-lang-ja/circleci:edition-guide-mdbook-0.4.5
     steps:
       - checkout
       - run: rustc --version --verbose
@@ -27,6 +27,12 @@ jobs:
       - run:
           name: Testing book
           command: mdbook test
+      - run:
+          name: Check for broken links
+          command: |
+            curl -sSLo linkcheck.sh \
+              https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh
+            sh linkcheck.sh --all edition-guide
       - run:
           name: If master branch, publish to GitHub Page
           command: |


### PR DESCRIPTION
サイトの生成に使用しているmdBookのバージョンを0.3.7から0.4.5へアップデートします。理由は、0.4.5より前のバージョンで生成したサイトの検索機能にセキュリティーの脆弱性があるためです。

脆弱性の詳細：
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26297
- https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html

mdBook 0.4.0〜0.4.5には `SUMMARY.md` 内にHTMLコメントがあるとサイトのビルドに失敗するという問題があります。そのため、当方にて修正したバージョンを使っています（mdBookのupstreamへ [pull request #1437](https://github.com/rust-lang/mdBook/pull/1437) を提出済み）

また、upstreamのGitHub Actionsワークフローを参考にリンク切れチェッカーを追加しました。

なお、同時にRustのバージョンも最新のnightlyへアップデートします。これにより #10 が解決する見込みです。

----
Fixes #10 