### PR TITLE
CIのリンク切れチェッカーを一時的にオフにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,12 @@ jobs:
       - run:
           name: Testing book
           command: mdbook test
-      - run:
-          name: Check for broken links
-          command: |
-            curl -sSLo linkcheck.sh \
-              https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh
-            sh linkcheck.sh --all edition-guide
+      # - run:
+      #     name: Check for broken links
+      #     command: |
+      #       curl -sSLo linkcheck.sh \
+      #         https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh
+      #       sh linkcheck.sh --all edition-guide
       - run:
           name: If master branch, publish to GitHub Page
           command: |


### PR DESCRIPTION
> また、upstreamのGitHub Actionsワークフローを参考にリンク切れチェッカーを追加しました。

#12 で追加したリンク切れチェッカーが以下のエラーになってしまったため一時的にオフにします。

[Circle CI Job 21](https://app.circleci.com/pipelines/github/rust-lang-ja/edition-guide/4/workflows/cea4a4a2-bf66-4ca1-b930-7a69e3dded60/jobs/21)

```console
#!/bin/bash -eo pipefail
curl -sSLo linkcheck.sh \
  https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh
sh linkcheck.sh --all edition-guide

error: toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed

Exited with code exit status 1

CircleCI received exit code 1
```
