### PR TITLE
1重スターで囲われた範囲を太字にするように変更（再）

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,4 +4,5 @@ multilingual = false
 src = "src"
 title = "The Edition Guide"
 
+[output.html]
 additional-css = ["theme/em-to-bold.css"]


### PR DESCRIPTION
https://github.com/rust-lang-ja/the-rust-programming-language-ja/issues/27

に対応します。https://github.com/rust-lang-ja/edition-guide/pull/15 の設定ファイルにミスがあったので、その修正です。

CIが生成したサイト（ https://15-328374033-gh.circle-artifacts.com/0/docs/rust-2015/index.html ）では**離れる**などが太字になっていることが確認できます。



