### PR TITLE
remove the annotation to use a branch version of mdbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@ Building the book requires [mdBook] 0.2. To get it:
 $ cargo install mdbook
 ```
 
-(日本語訳版追記)
-日本語翻訳版のビルドには `rust-lang-ja` にあるmdBookのフォークを使う必要があります。
-
-```bash
-$ cargo install mdbook --git https://github.com/rust-lang-ja/mdBook \
-    --branch summary-with-html-comments
-```
-
 ### Building
 
 The most straight-forward way to build and view the book locally is to use the following command:


### PR DESCRIPTION
mdbook 0.4.8で日本語版ビルドの問題が解消したのでフォーク版仕様の注記を削除しました。