### PR TITLE
04-07 コードブロック関連のMarkdown書式の修正

### DIFF
--- a/src/rust-2021/warnings-promoted-to-error.md
+++ b/src/rust-2021/warnings-promoted-to-error.md
@@ -51,6 +51,7 @@ pub fn my_function(_trait_object: &MyTrait) { // should be `&dyn MyTrait`
                                               // `&dyn MyTrait` と書かなくてはならない
   unimplemented!()
 }
+```
 
 ### `ellipsis_inclusive_range_patterns`:
 
@@ -70,12 +71,12 @@ just a lint in Rust 2021:
 
 例えば、次のコードはパターンとして `...` を使っているため、Rust 2021 ではただのリントではなくエラーが発生します:
 
-<!--
 ```rust
 pub fn less_or_eq_to_100(n: u8) -> bool {
   matches!(n, 0...100) // should be `0..=100`
                        // `0..=100` と書かなくてはならない
 }
+```
 
 <!--
 ## Migrations 


### PR DESCRIPTION
コードブロック関連のMarkdown書式が崩れてしまったので修正する。

`<!--`の削除漏れは、修正範囲の選択ミスと思われる。

コードブロックの終了を表す ` ``` ` が抜けているのは、GitHub PRレビューコメントのsuggestion機能の誤動作と考えられる。（` ```diff`〜` ``` `と` ```rust `〜` ``` `がネストしてるとおかしくなる？）