### PR TITLE
CI: mdBook v0.4.13とRust 1.56.1へアップデート

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:edition-guide-mdbook-0.4.5
+      - image: quay.io/rust-lang-ja/circleci:edition-guide-mdbook-0.4.13
     steps:
       - checkout
       - run: rustc --version --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
       - store_artifacts:
           path: /tmp/docs.txz
           destination: docs.txz
-      # - run:
-      #     name: Testing book
-      #     command: mdbook test
+      - run:
+          name: Testing book
+          command: mdbook test
       # - run:
       #     name: Check for broken links
       #     command: |


### PR DESCRIPTION
Circle CIのジョブを変更します。

- 最新のCI用Dockerイメージを使用する（mdBook v0.4.13とRust 1.56.1）
    - Fixes #20
- `mdbook test`コマンドが再び実行されるようにする
   - Fixes #22
