### PR TITLE
CI：mdbookのバージョンをv0.4.43へアップデートする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:edition-guide-mdbook-0.4.13
+      - image: quay.io/rust-lang-ja/circleci:edition-guide-mdbook-0.4.43
     steps:
       - checkout
       - run: rustc --version --verbose


### PR DESCRIPTION
Circle CIで使用する`mdbook`のバージョンを`v0.4.43`へアップデートします。