### PR TITLE
「never 型のフォールバック先の変更」を翻訳

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -121,7 +121,7 @@
     - [Unsafe attributes](rust-2024/unsafe-attributes.md)
     - [`unsafe_op_in_unsafe_fn` warning](rust-2024/unsafe-op-in-unsafe-fn.md)
     - [Disallow references to `static mut`](rust-2024/static-mut-references.md)
-    - [ネバー型のフォールバック先の変更](rust-2024/never-type-fallback.md)
+    - [never 型のフォールバック先の変更](rust-2024/never-type-fallback.md)
     - [Macro fragment specifiers](rust-2024/macro-fragment-specifiers.md)
     - [Missing macro fragment specifiers](rust-2024/missing-macro-fragment-specifiers.md)
     - [`gen` keyword](rust-2024/gen-keyword.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -121,7 +121,7 @@
     - [Unsafe attributes](rust-2024/unsafe-attributes.md)
     - [`unsafe_op_in_unsafe_fn` warning](rust-2024/unsafe-op-in-unsafe-fn.md)
     - [Disallow references to `static mut`](rust-2024/static-mut-references.md)
-    - [Never type fallback change](rust-2024/never-type-fallback.md)
+    - [ネバー型のフォールバック先の変更](rust-2024/never-type-fallback.md)
     - [Macro fragment specifiers](rust-2024/macro-fragment-specifiers.md)
     - [Missing macro fragment specifiers](rust-2024/missing-macro-fragment-specifiers.md)
     - [`gen` keyword](rust-2024/gen-keyword.md)


### PR DESCRIPTION
Closes #102 

「フォールバック」という概念に馴染みがない場合に備え、一部意訳を加えてニュアンスを丁寧に伝えています。